### PR TITLE
feat: add build pipeline for tester

### DIFF
--- a/BUILD_AND_TEST_GUIDE.md
+++ b/BUILD_AND_TEST_GUIDE.md
@@ -1,0 +1,116 @@
+# Shards of Dawn - Build & Test Guide cho Tester
+
+## Yeu cau he thong
+
+- **OS:** Windows 10/11 (64-bit)
+- **Unreal Engine:** 5.4+ (cai qua Epic Games Launcher)
+- **Visual Studio:** 2022 voi C++ game development workload
+- **RAM:** 16GB+ (khuyen nghi 32GB)
+- **Disk:** 50GB free
+
+## Cach 1: Build nhanh bang Script (Khuyen nghi)
+
+### Buoc 1: Clone repo
+```
+git clone <repo-url>
+cd gameittakes2
+git checkout claude/build-game-for-testing-Ad2FN
+```
+
+### Buoc 2: Set UE5 path (neu can)
+```
+set UE5_ROOT=C:\Program Files\Epic Games\UE_5.4
+```
+
+### Buoc 3: Build game
+```
+BuildGame.bat package
+```
+
+Script se tu dong:
+1. Compile C++ source
+2. Cook content (materials, blueprints, maps)
+3. Package thanh executable
+
+### Buoc 4: Chay game
+```
+Build\Packaged\WindowsNoEditor\ShardsOfDawn.exe
+```
+
+## Cach 2: Build trong UE5 Editor
+
+### Buoc 1: Mo project
+- Mo `ShardsOfDawn.uproject` bang UE5 5.4+
+- Cho compile C++ xong (thanh progress bar phia duoi)
+
+### Buoc 2: Validate environment
+- Chay `automation/setup_editor.bat` (kiem tra plugins, settings)
+
+### Buoc 3: Test trong Editor (nhanh nhat)
+1. Mo map: `Content/Game/Maps/PrototypeRoom`
+2. World Settings > Game Mode = `BP_SodGameMode`
+3. Bam **Play** (2 players split-screen):
+   - Toolbar > Play > Advanced > **Number of Players = 2**
+   - Hoac dung **Standalone Game** voi `-game -numplayers=2`
+
+### Buoc 4: Package tu Editor
+1. **Platforms > Windows > Package Project**
+2. Chon thu muc output
+3. Doi build xong (~10-20 phut)
+
+## Cac lenh BuildGame.bat
+
+| Lenh | Mo ta |
+|------|-------|
+| `BuildGame.bat package` | Full build + cook + package (cho tester) |
+| `BuildGame.bat build` | Chi compile C++ (kiem tra loi nhanh) |
+| `BuildGame.bat cook` | Chi cook content |
+| `BuildGame.bat clean` | Xoa build artifacts |
+| `BuildGame.bat editor` | Mo UE5 Editor |
+
+## Test Plan cho Tester
+
+### Quick Test (5 phut)
+1. Chay game
+2. Kiem tra 2 player spawn dung vi tri
+3. WASD + Mouse di chuyen OK
+4. Nhan E tuong tac voi Light/Shadow Shard
+5. Puzzle co hoat dong (bridge ha xuong khi giai xong)
+
+### Full Smoke Test
+Xem file: `qa/SMOKE_TEST_CHECKLIST.md`
+
+### Controls
+
+| Key | Action |
+|-----|--------|
+| WASD | Di chuyen |
+| Mouse | Xoay camera |
+| Space | Nhay |
+| Shift | Chay nhanh |
+| E | Tuong tac |
+| Q | Ability chinh |
+| R | Ability phu |
+| T | Ping vi tri cho dong doi |
+
+## Troubleshooting
+
+### Loi "Module not found"
+- Kiem tra da cai UE5 5.4+ chua
+- Chay `BuildGame.bat clean` roi build lai
+
+### Loi compile C++
+- Kiem tra Visual Studio 2022 voi "Game development with C++" workload
+- Mo `.uproject` trong VS va build lai
+
+### Game crash khi chay
+- Kiem tra GPU driver moi nhat
+- Thu tat Ray Tracing trong DefaultEngine.ini:
+  ```
+  r.RayTracing=False
+  r.Lumen.DiffuseIndirectLighting.HardwareRayTracing=False
+  ```
+
+### 2 players khong spawn
+- Kiem tra World Settings > Game Mode = BP_SodGameMode
+- Kiem tra co 2 PlayerStart trong map (tag: Light va Shadow)

--- a/BuildGame.bat
+++ b/BuildGame.bat
@@ -1,0 +1,159 @@
+@echo off
+REM ============================================================================
+REM  Shards of Dawn - Build Script for Testing
+REM  Usage: BuildGame.bat [build|cook|package|clean]
+REM  Default: package (full build + cook + package)
+REM ============================================================================
+
+setlocal EnableDelayedExpansion
+
+REM ── Auto-detect UE5 installation ──────────────────────────────────────────
+set "UE_ROOT="
+
+REM Check common installation paths
+if exist "C:\Program Files\Epic Games\UE_5.4\Engine\Build\BatchFiles\RunUAT.bat" (
+    set "UE_ROOT=C:\Program Files\Epic Games\UE_5.4"
+)
+if exist "C:\Program Files\Epic Games\UE_5.5\Engine\Build\BatchFiles\RunUAT.bat" (
+    set "UE_ROOT=C:\Program Files\Epic Games\UE_5.5"
+)
+if exist "D:\Epic Games\UE_5.4\Engine\Build\BatchFiles\RunUAT.bat" (
+    set "UE_ROOT=D:\Epic Games\UE_5.4"
+)
+if exist "D:\Epic Games\UE_5.5\Engine\Build\BatchFiles\RunUAT.bat" (
+    set "UE_ROOT=D:\Epic Games\UE_5.5"
+)
+
+REM Allow override via environment variable
+if defined UE5_ROOT (
+    set "UE_ROOT=%UE5_ROOT%"
+)
+
+if "%UE_ROOT%"=="" (
+    echo [ERROR] Could not find Unreal Engine 5.4+
+    echo Please set UE5_ROOT environment variable to your UE5 installation path
+    echo Example: set UE5_ROOT=C:\Program Files\Epic Games\UE_5.4
+    exit /b 1
+)
+
+echo [INFO] Using Unreal Engine at: %UE_ROOT%
+
+set "UAT=%UE_ROOT%\Engine\Build\BatchFiles\RunUAT.bat"
+set "UBT=%UE_ROOT%\Engine\Binaries\DotNET\UnrealBuildTool\UnrealBuildTool.exe"
+set "EDITOR_CMD=%UE_ROOT%\Engine\Binaries\Win64\UnrealEditor-Cmd.exe"
+set "PROJECT_DIR=%~dp0"
+set "UPROJECT=%PROJECT_DIR%ShardsOfDawn.uproject"
+set "BUILD_DIR=%PROJECT_DIR%Build\Packaged"
+set "PLATFORM=Win64"
+set "CONFIG=Development"
+
+REM ── Parse command ─────────────────────────────────────────────────────────
+set "COMMAND=%~1"
+if "%COMMAND%"=="" set "COMMAND=package"
+
+echo.
+echo ============================================================================
+echo  SHARDS OF DAWN - Build System
+echo  Command: %COMMAND%
+echo  Platform: %PLATFORM%
+echo  Config: %CONFIG%
+echo  Project: %UPROJECT%
+echo ============================================================================
+echo.
+
+if /i "%COMMAND%"=="build" goto :BUILD
+if /i "%COMMAND%"=="cook" goto :COOK
+if /i "%COMMAND%"=="package" goto :PACKAGE
+if /i "%COMMAND%"=="clean" goto :CLEAN
+if /i "%COMMAND%"=="editor" goto :EDITOR
+
+echo [ERROR] Unknown command: %COMMAND%
+echo Usage: BuildGame.bat [build^|cook^|package^|clean^|editor]
+exit /b 1
+
+REM ── BUILD: Compile C++ only ───────────────────────────────────────────────
+:BUILD
+echo [STEP 1/1] Compiling C++ source...
+"%UBT%" ShardsOfDawn %PLATFORM% %CONFIG% -Project="%UPROJECT%" -WaitMutex -FromMsBuild
+if %ERRORLEVEL% NEQ 0 (
+    echo [FAILED] C++ compilation failed!
+    exit /b %ERRORLEVEL%
+)
+echo [SUCCESS] C++ compilation completed!
+goto :END
+
+REM ── COOK: Cook content only ───────────────────────────────────────────────
+:COOK
+echo [STEP 1/1] Cooking content for %PLATFORM%...
+"%EDITOR_CMD%" "%UPROJECT%" -run=cook -targetplatform=%PLATFORM% -iterate -unversioned
+if %ERRORLEVEL% NEQ 0 (
+    echo [FAILED] Content cooking failed!
+    exit /b %ERRORLEVEL%
+)
+echo [SUCCESS] Content cooking completed!
+goto :END
+
+REM ── PACKAGE: Full build + cook + package ──────────────────────────────────
+:PACKAGE
+echo [STEP 1/1] Running full package pipeline...
+echo   This will: Compile C++ -^> Cook Content -^> Package Game
+echo   Output: %BUILD_DIR%
+echo.
+
+call "%UAT%" BuildCookRun ^
+    -project="%UPROJECT%" ^
+    -noP4 ^
+    -platform=%PLATFORM% ^
+    -clientconfig=%CONFIG% ^
+    -cook ^
+    -build ^
+    -stage ^
+    -pak ^
+    -archive ^
+    -archivedirectory="%BUILD_DIR%" ^
+    -prereqs ^
+    -nodebuginfo ^
+    -utf8output ^
+    -compile
+
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo [FAILED] Package build failed! Check errors above.
+    echo Common fixes:
+    echo   1. Make sure Visual Studio 2022 is installed with C++ game dev workload
+    echo   2. Run setup_editor.bat first
+    echo   3. Check that .uproject opens correctly in UE5 Editor
+    exit /b %ERRORLEVEL%
+)
+
+echo.
+echo ============================================================================
+echo  [SUCCESS] Game packaged successfully!
+echo  Output: %BUILD_DIR%\WindowsNoEditor
+echo.
+echo  To run the game:
+echo    %BUILD_DIR%\WindowsNoEditor\ShardsOfDawn.exe
+echo ============================================================================
+goto :END
+
+REM ── CLEAN: Remove build artifacts ─────────────────────────────────────────
+:CLEAN
+echo [CLEANING] Removing build artifacts...
+if exist "%PROJECT_DIR%Binaries" rmdir /s /q "%PROJECT_DIR%Binaries"
+if exist "%PROJECT_DIR%Intermediate" rmdir /s /q "%PROJECT_DIR%Intermediate"
+if exist "%PROJECT_DIR%Saved" rmdir /s /q "%PROJECT_DIR%Saved"
+if exist "%BUILD_DIR%" rmdir /s /q "%BUILD_DIR%"
+echo [SUCCESS] Build artifacts cleaned!
+goto :END
+
+REM ── EDITOR: Open in UE5 Editor ────────────────────────────────────────────
+:EDITOR
+echo [OPENING] Launching UE5 Editor...
+start "" "%UE_ROOT%\Engine\Binaries\Win64\UnrealEditor.exe" "%UPROJECT%"
+echo [INFO] Editor is starting...
+goto :END
+
+:END
+echo.
+echo Done.
+endlocal

--- a/BuildGame.sh
+++ b/BuildGame.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# ============================================================================
+#  Shards of Dawn - Build Script for Testing (macOS/Linux)
+#  Usage: ./BuildGame.sh [build|cook|package|clean]
+#  Default: package (full build + cook + package)
+# ============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPROJECT="${SCRIPT_DIR}/ShardsOfDawn.uproject"
+BUILD_DIR="${SCRIPT_DIR}/Build/Packaged"
+PLATFORM="Linux"
+CONFIG="Development"
+
+# ── Auto-detect UE5 installation ──────────────────────────────────────────
+if [ -z "${UE5_ROOT}" ]; then
+    # Common Linux/Mac paths
+    for UE_PATH in \
+        "/opt/UnrealEngine" \
+        "$HOME/UnrealEngine" \
+        "/Users/Shared/Epic Games/UE_5.4" \
+        "/Applications/UnrealEngine/UE_5.4"; do
+        if [ -f "${UE_PATH}/Engine/Build/BatchFiles/RunUAT.sh" ]; then
+            UE5_ROOT="${UE_PATH}"
+            break
+        fi
+    done
+fi
+
+if [ -z "${UE5_ROOT}" ]; then
+    echo "[ERROR] Could not find Unreal Engine 5.4+"
+    echo "Please set UE5_ROOT environment variable"
+    echo "Example: export UE5_ROOT=/opt/UnrealEngine"
+    exit 1
+fi
+
+echo "[INFO] Using Unreal Engine at: ${UE5_ROOT}"
+
+UAT="${UE5_ROOT}/Engine/Build/BatchFiles/RunUAT.sh"
+EDITOR_CMD="${UE5_ROOT}/Engine/Binaries/Linux/UnrealEditor-Cmd"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    PLATFORM="Mac"
+    EDITOR_CMD="${UE5_ROOT}/Engine/Binaries/Mac/UnrealEditor-Cmd"
+fi
+
+COMMAND="${1:-package}"
+
+echo ""
+echo "============================================================================"
+echo "  SHARDS OF DAWN - Build System"
+echo "  Command: ${COMMAND}"
+echo "  Platform: ${PLATFORM}"
+echo "  Config: ${CONFIG}"
+echo "============================================================================"
+echo ""
+
+case "${COMMAND}" in
+    build)
+        echo "[STEP 1/1] Compiling C++ source..."
+        "${UAT}" BuildCookRun \
+            -project="${UPROJECT}" \
+            -noP4 \
+            -platform="${PLATFORM}" \
+            -clientconfig="${CONFIG}" \
+            -build \
+            -skipstage \
+            -utf8output
+        echo "[SUCCESS] C++ compilation completed!"
+        ;;
+
+    cook)
+        echo "[STEP 1/1] Cooking content..."
+        "${EDITOR_CMD}" "${UPROJECT}" \
+            -run=cook \
+            -targetplatform="${PLATFORM}" \
+            -iterate \
+            -unversioned
+        echo "[SUCCESS] Content cooking completed!"
+        ;;
+
+    package)
+        echo "[STEP 1/1] Running full package pipeline..."
+        echo "  Output: ${BUILD_DIR}"
+
+        "${UAT}" BuildCookRun \
+            -project="${UPROJECT}" \
+            -noP4 \
+            -platform="${PLATFORM}" \
+            -clientconfig="${CONFIG}" \
+            -cook \
+            -build \
+            -stage \
+            -pak \
+            -archive \
+            -archivedirectory="${BUILD_DIR}" \
+            -prereqs \
+            -nodebuginfo \
+            -utf8output \
+            -compile
+
+        echo ""
+        echo "============================================================================"
+        echo "  [SUCCESS] Game packaged successfully!"
+        echo "  Output: ${BUILD_DIR}/${PLATFORM}NoEditor"
+        echo "============================================================================"
+        ;;
+
+    clean)
+        echo "[CLEANING] Removing build artifacts..."
+        rm -rf "${SCRIPT_DIR}/Binaries"
+        rm -rf "${SCRIPT_DIR}/Intermediate"
+        rm -rf "${SCRIPT_DIR}/Saved"
+        rm -rf "${BUILD_DIR}"
+        echo "[SUCCESS] Build artifacts cleaned!"
+        ;;
+
+    *)
+        echo "[ERROR] Unknown command: ${COMMAND}"
+        echo "Usage: ./BuildGame.sh [build|cook|package|clean]"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "Done."

--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -4,3 +4,21 @@ ProjectName=Shards of Dawn
 Description=Co-op prototype focused on Light/Shadow interaction
 CompanyName=Independent
 ProjectDisplayedTitle=NSLOCTEXT("[Project]", "D4F39A214E1E4B5BA7F1B6D6A0E8D0C1", "Shards of Dawn")
+
+[/Script/UnrealEd.ProjectPackagingSettings]
+BuildConfiguration=Development
+StagingDirectory=(Path="Build/Packaged")
+FullRebuild=False
+ForDistribution=False
+IncludeDebugFiles=True
+BlueprintNativizationMethod=Disabled
+bShareMaterialShaderCode=True
+bCompressed=True
++MapsToCook=(FilePath="/Game/Maps/PrototypeRoom")
++DirectoriesToAlwaysCook=(Path="/Game/Blueprints")
++DirectoriesToAlwaysCook=(Path="/Game/GameModes")
++DirectoriesToAlwaysCook=(Path="/Game/Input")
++DirectoriesToAlwaysCook=(Path="/Game/Materials")
+
+[/Script/Engine.GameSession]
+MaxPlayers=2


### PR DESCRIPTION
## Summary
- Add packaging settings to `DefaultGame.ini` (maps to cook, staging directory, compression)
- Add `BuildGame.bat` (Windows) and `BuildGame.sh` (Linux/Mac) build scripts with auto-detect UE5 path
- Add `BUILD_AND_TEST_GUIDE.md` with step-by-step instructions for testers

## How to build

```bash
git checkout claude/build-game-for-testing-Ad2FN
BuildGame.bat package
```

Game output: `Build/Packaged/WindowsNoEditor/ShardsOfDawn.exe`

## Test plan
- [ ] Clone branch and run `BuildGame.bat package` on Windows with UE5 5.4+
- [ ] Verify game launches and PrototypeRoom map loads
- [ ] Run quick smoke test: 2-player spawn, WASD movement, E interact with shards
- [ ] Full smoke test per `qa/SMOKE_TEST_CHECKLIST.md`

https://claude.ai/code/session_016rpBrjSNGWq9j6YJNd91nN